### PR TITLE
add RTE opendata in portals list

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -127,7 +127,8 @@ portals <- function(){
                              "Tourisme Pas-de-Calais",
                              "D\u00E9partement des Hauts-de-Seine",
                              "Minist\u00E8re de l'Education Nationale, de l'Enseignement sup\u00E9rieur et de la Recherche",
-                             "ERDF"),
+                             "ERDF",
+                             "RTE"),
                     portals = c("ratp",
                                 "iledefrance",
                                 "infogreffe",
@@ -140,7 +141,8 @@ portals <- function(){
                                 "62",
                                 "92",
                                 "enesr",
-                                "erdf"),
+                                "erdf", 
+                                "rte"),
                     base_urls = c("http://data.ratp.fr",
                                   "http://data.iledefrance.fr",
                                   "http://datainfogreffe.fr",
@@ -153,7 +155,8 @@ portals <- function(){
                                   "http://tourisme62.opendatasoft.com",
                                   "https://opendata.hauts-de-seine.fr",
                                   "http://data.enseignementsup-recherche.gouv.fr",
-                                  "https://data.erdf.fr"))
+                                  "https://data.erdf.fr", 
+                                  "https://opendata.rte-france.com"))
 }
 
 get_base_url <- function(portal){


### PR DESCRIPTION
Hi, 

I add one database in the the list. It's the [opendata platform of RTE](https://opendata.rte-france.com/page/accueil/)  (Réseau Transport d'Electricité) which works with Open Data Soft. 

basicaly, I just add one line in your `portals` constant.

By the way, I had the project of creating and API between R and RTE open data platform. But I found your project and it fill the need. I will maybe buid something around `fodr`, will see. 
However, if you want some help to this project, I'll be happy to contribute. 

Thanks for this project.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tutuchan/fodr/5)

<!-- Reviewable:end -->
